### PR TITLE
Fix as number of images instead of eposide in rollouts

### DIFF
--- a/collect_rollouts.py
+++ b/collect_rollouts.py
@@ -30,7 +30,6 @@ def collect_rollouts(config, envs, agent):
     agent_state = None
     reward = [0] * len(envs)
 
-    images = os.listdir(save_dir)
 
     image_num = 0
 
@@ -65,7 +64,7 @@ def collect_rollouts(config, envs, agent):
         done = np.stack(done)
         info = list(info)
 
-        images = os.listdir(save_dir)
+        images = list(pathlib.Path(save_dir).rglob("*.png"))
         image_num = len(images)
 
 


### PR DESCRIPTION
The directory `rollouts/minedojo_task/image_from_agent/timestamp` is usually saved as `episode_x/image/step.png`, while `os.listdir` retrieves the folder under `episode_x`. The  `image_num` is not the number of images but the episode. 

By default, the `rollout_image_num` in `config.yaml` is set to 2000, which is consistent with the number of images used to train U-Net in the paper. Therefore, `pathlib` should be used instead of `os.listdir` to recursively retrieve images.